### PR TITLE
Set more fields on the request

### DIFF
--- a/lib/opinionated_http/client.rb
+++ b/lib/opinionated_http/client.rb
@@ -55,7 +55,7 @@ module OpinionatedHTTP
       response.body
     end
 
-    def post(action:, path: "/#{action}", headers: nil, body: nil, form_data: nil, auth: nil)
+    def post(action:, path: "/#{action}", headers: nil, body: nil, form_data: nil, username: nil, password: nil)
       path    = "/#{path}" unless path.start_with?("/")
       request = generic_request(path: path, verb: 'Post', headers: headers, body: body, form_data: form_data, auth: auth)
 
@@ -64,15 +64,14 @@ module OpinionatedHTTP
       response.body
     end
 
-    # auth expects hash of the form {'username' =>, 'password' =>}
-    def generic_request(path:, verb:, headers: nil, body: nil, form_data: nil, auth: nil)
+    def generic_request(path:, verb:, headers: nil, body: nil, form_data: nil, username: nil, password: nil)
       raise(ArgumentError, 'setting form data will overwrite supplied content-type') unless headers_and_form_data_compatible? headers, form_data
       raise(ArgumentError, 'setting form data will overwrite supplied body') if body && form_data
 
       request = Net::HTTP.const_get(verb).new(path, headers)
       request.body = body if body
       request.set_form_data form_data if form_data
-      request.basic_auth(auth['username'], auth['password']) if auth
+      request.basic_auth(username, password) if username && password
       request
     end
 

--- a/lib/opinionated_http/client.rb
+++ b/lib/opinionated_http/client.rb
@@ -49,20 +49,31 @@ module OpinionatedHTTP
       path = "/#{path}" unless path.start_with?("/")
       path = "#{path}?#{URI.encode_www_form(parameters)}" if parameters
 
-      request  = Net::HTTP::Get.new(path)
+      request  = generic_request(path: path, verb: 'Get')
       response = request_with_retry(action: action, path: path, request: request)
 
       response.body
     end
 
-    def post(action:, path: "/#{action}", parameters: nil)
+    def post(action:, path: "/#{action}", headers: nil, body: nil, form_data: nil, auth: nil)
       path    = "/#{path}" unless path.start_with?("/")
-      request = Net::HTTP::Post.new(path)
-      request.set_form_data(parameters) if parameters
+      request = generic_request(path: path, verb: 'Post', headers: headers, body: body, form_data: form_data, auth: auth)
 
       response = request_with_retry(action: action, path: path, request: request)
 
       response.body
+    end
+
+    # auth expects hash of the form {'username' =>, 'password' =>}
+    def generic_request(path:, verb:, headers: nil, body: nil, form_data: nil, auth: nil)
+      raise(ArgumentError, 'setting form data will overwrite supplied content-type') unless headers_and_form_data_compatible? headers, form_data
+      raise(ArgumentError, 'setting form data will overwrite supplied body') if body && form_data
+
+      request = Net::HTTP.const_get(verb).new(path, headers)
+      request.body = body if body
+      request.set_form_data form_data if form_data
+      request.basic_auth(auth['username'], auth['password']) if auth
+      request
     end
 
     private
@@ -112,6 +123,11 @@ module OpinionatedHTTP
     def retry_sleep_interval(retry_count)
       return 0 if retry_count <= 1
       (retry_multiplier ** (retry_count - 1)) * retry_interval
+    end
+
+    def headers_and_form_data_compatible?(headers, form_data)
+      return true if headers.nil? || form_data.nil?
+      !headers.keys.map(&:downcase).include? 'content-type'
     end
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -35,7 +35,7 @@ module OpinionatedHTTP
         let(:get_verb) { 'Get' }
 
         it 'creates a request corresponding to the supplied verb' do
-          req = http.generic_request(path: path, verb: post_verb)
+          req  = http.generic_request(path: path, verb: post_verb)
           req2 = http.generic_request(path: path, verb: get_verb)
 
           assert_kind_of Net::HTTP::Post, req
@@ -44,7 +44,7 @@ module OpinionatedHTTP
 
         it 'returns a request with supplied headers' do
           test_headers = {'test1' => 'yes_test_1', 'test2' => 'yes_test_2'}
-          req = http.generic_request(path: path, verb: get_verb, headers: test_headers)
+          req          = http.generic_request(path: path, verb: get_verb, headers: test_headers)
 
           assert_equal test_headers['test1'], req['test1']
           assert_equal test_headers['test2'], req['test2']
@@ -52,7 +52,7 @@ module OpinionatedHTTP
 
         it 'returns a request with supplied body' do
           test_body = "nice bod"
-          req = http.generic_request(path: path, verb: get_verb, body: test_body)
+          req       = http.generic_request(path: path, verb: get_verb, body: test_body)
 
           assert_equal test_body, req.body
         end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -67,10 +67,11 @@ module OpinionatedHTTP
         end
 
         it 'add supplied authentication to the request' do
-          test_auth = {'username' => 'admin', 'password' => 'hunter2'}
-          req = http.generic_request(path: path, verb: get_verb, auth: test_auth)
+          test_un = 'admin'
+          test_pw = 'hunter2'
+          req = http.generic_request(path: path, verb: get_verb, username: test_un, password: test_pw)
           req2 = Net::HTTP::Get.new(path)
-          req2.basic_auth test_auth['username'], test_auth['password']
+          req2.basic_auth test_un, test_pw
 
           assert_equal req2['authorization'], req['authorization']
         end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -28,6 +28,82 @@ module OpinionatedHTTP
           # end
         end
       end
+
+      describe "generic_request" do
+        let(:path) { '/fake_action' }
+        let(:post_verb) { 'Post' }
+        let(:get_verb) { 'Get' }
+
+        it 'creates a request corresponding to the supplied verb' do
+          req = http.generic_request(path: path, verb: post_verb)
+          req2 = http.generic_request(path: path, verb: get_verb)
+
+          assert_kind_of Net::HTTP::Post, req
+          assert_kind_of Net::HTTP::Get, req2
+        end
+
+        it 'returns a request with supplied headers' do
+          test_headers = {'test1' => 'yes_test_1', 'test2' => 'yes_test_2'}
+          req = http.generic_request(path: path, verb: get_verb, headers: test_headers)
+
+          assert_equal test_headers['test1'], req['test1']
+          assert_equal test_headers['test2'], req['test2']
+        end
+
+        it 'returns a request with supplied body' do
+          test_body = "nice bod"
+          req = http.generic_request(path: path, verb: get_verb, body: test_body)
+
+          assert_equal test_body, req.body
+        end
+
+        it 'returns a request with supplied form data in x-www-form-urlencoded Content-Type' do
+          test_data = {test1: 'yes', test2: 'no'}
+          expected_string = "test1=yes&test2=no"
+          req = http.generic_request(path: path, verb: post_verb, form_data: test_data)
+
+          assert_equal expected_string, req.body
+          assert_equal 'application/x-www-form-urlencoded', req['Content-Type']
+        end
+
+        it 'add supplied authentication to the request' do
+          test_auth = {'username' => 'admin', 'password' => 'hunter2'}
+          req = http.generic_request(path: path, verb: get_verb, auth: test_auth)
+          req2 = Net::HTTP::Get.new(path)
+          req2.basic_auth test_auth['username'], test_auth['password']
+
+          assert_equal req2['authorization'], req['authorization']
+        end
+
+        it 'raise an error if supplied content-type header would be overwritten by setting form_data' do
+          downcase_headers    = {'unimportant' => 'blank', 'content-type' => 'application/json'}
+          capitalized_headers = {'Unimportant' => 'blank', 'Content-Type' => 'application/json'}
+          no_conflict_headers = {'whatever' => 'blank', 'irrelevant' => 'test'}
+          form_data           = {thing1: 1, thing2: 2}
+
+          assert_raises ArgumentError do
+            http.generic_request(path: path, verb: post_verb, headers: downcase_headers, form_data: form_data)
+          end
+
+          assert_raises ArgumentError do
+            http.generic_request(path: path, verb: post_verb, headers: capitalized_headers, form_data: form_data)
+          end
+
+          assert http.generic_request(path: path, verb: post_verb, headers: no_conflict_headers, form_data: form_data)
+        end
+
+        it 'raise an error if there is a collision between supplied body and form_data' do
+          form_data = {thing1: 1, thing2: 2}
+          body      = "not form data"
+
+          assert_raises ArgumentError do
+            http.generic_request(path: path, verb: post_verb, body: body, form_data: form_data)
+          end
+
+          assert http.generic_request(path: path, verb: post_verb, body: body)
+          assert http.generic_request(path: path, verb: post_verb, form_data: form_data)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Issue 1 (if available)
closes #1

### Description of changes
extend Client#post to be able to set more fields in the request including headers, body, and authentication with basic_auth

create Client#generic_request for code reuse and testing purposes

check args to generic_request for collisions and raise ArgumentErrors rather than allow fields to be overwritten

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.